### PR TITLE
Change name fetch to handle nil values

### DIFF
--- a/app/services/orcid/remote/profile_query_service/response_parser.rb
+++ b/app/services/orcid/remote/profile_query_service/response_parser.rb
@@ -42,7 +42,8 @@ module Orcid
         def extract_label(identifier, profile)
           orcid_bio = profile.fetch('orcid-bio')
           given_names = orcid_bio.fetch('personal-details').fetch('given-names').fetch('value')
-          family_name = orcid_bio.fetch('personal-details').fetch('family-name').fetch('value')
+          # family name is not a required field on orcid record
+          family_name = orcid_bio.try(:[], 'personal-details').try(:[], 'family_name').try(:[], 'value')
           emails = []
           contact_details = orcid_bio['contact-details']
           if contact_details


### PR DESCRIPTION
Fixes https://github.com/uclibs/scholar_uc/issues/997

Orcid widget includes `look up my existing orcid id` form which pre-populates user name in the search form field. In the results list, a record with nil family_name will result in critical error (last name is not required on ORCID record).

This fix handles nil family_names gracefully.

* Replace chained fetch for names hash chain of trys